### PR TITLE
[semver:<segment>] Remove file on cf-install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,26 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
- - Current development changes [ to be moved to release ]
+
+- Current development changes [ to be moved to release ]
 
 ## [1.0.0] - YYYY-MM-DD
-### Added
- - Initial Release
-### Changed
- - Initial Release
-### Removed
- - Initial Release
 
+### Added
+
+- Initial Release
+
+### Changed
+
+- Initial Release
+
+### Removed
+
+- Initial Release
 
 [1.0.0]: GITHUB TAG URL

--- a/src/commands/cf-install.yml
+++ b/src/commands/cf-install.yml
@@ -11,7 +11,6 @@ steps:
       name: "Setup CF CLI"
       command: |
         curl -L -o cf.deb --retry 3 'https://packages.cloudfoundry.org/stable?release=debian64&version=<< parameters.version >>&source=github-rel'
-        file cf.deb
         sudo dpkg -i cf.deb
         cf -v
         cf api "$CF_ENDPOINT"


### PR DESCRIPTION
## Description:

Update to using `ls` over `file`

## Motivation:

The file cli is deprecated on newer base images

