### PR TITLE
[semver:patch] HOTT-1687 Support release note branches

### DIFF
--- a/src/commands/generate-release-notes.yml
+++ b/src/commands/generate-release-notes.yml
@@ -23,6 +23,8 @@ steps:
         LAST_RELEASE=$(git tag --list 'release-202*-*' | sort | tail -n 1)
         if [[ -z "${LAST_RELEASE}" ]]; then
           echo "First release" > << parameters.release-notes-file >>
+        elif [[ $(echo "$CIRCLE_BRANCH" | egrep '^hotfix\/') ]]; then
+          git log --format=format:"* %s" $LAST_RELEASE..HEAD > << parameters.release-notes-file >>
         else
           git log --merges --format=format:"* %b" $LAST_RELEASE..HEAD > << parameters.release-notes-file >>
 


### PR DESCRIPTION
Parse out release notes for Hotfix releases

This are released out of branches rather then off main so should list commits directly instead of only merge commits