### PR TITLE
BAU: Add "comment Terraform plan" job

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -15,3 +15,4 @@ orbs:
   aws-cli: circleci/aws-cli@2.0.3
   gh: circleci/github-cli@1.0
   slack: circleci/slack@4.3.0
+  terraform: circleci/terraform@3.2.0

--- a/src/commands/comment-terraform-plan.yml
+++ b/src/commands/comment-terraform-plan.yml
@@ -1,0 +1,30 @@
+description: >
+  Extract the output of `terraform plan` and comment on a PR.
+
+parameters:
+  path:
+    type: string
+    default: "./tfplan"
+    description: "The path to the output of terraform plan."
+  github_token:
+    type: env_var_name
+    default: GITHUB_TOKEN
+    description: "The environment variable that contains the GitHub token of the user that will post the comment."
+  github_user:
+    type: env_var_name
+    default: GITHUB_USER
+    description: "The environment variable that contains the GitHub username of the user that will post the comment."
+
+steps:
+  - terraform/init
+  - run:
+      name: Install Dependencies
+      command: |
+        apk add --no-cache jq jo curl
+  - run:
+      name: Comment on Pull Request
+      environment:
+        PARAM_PLAN: << parameters.path >>
+        GITHUB_TOKEN_ENV_VAR_NAME: << parameters.github_token >>
+        GITHUB_USER_ENV_VAR_NAME: << parameters.github_user >>
+      command: <<include(scripts/comment-terraform-plan.sh)>>

--- a/src/jobs/comment-terraform-plan.yml
+++ b/src/jobs/comment-terraform-plan.yml
@@ -16,7 +16,7 @@ parameters:
 executor: default
 
 steps:
-  - comment_terraform_plan:
+  - comment-terraform-plan:
       path: << parameters.path >>
       github_token: << parameters.github_token >>
       github_user: << parameters.github_user >>

--- a/src/jobs/comment-terraform-plan.yml
+++ b/src/jobs/comment-terraform-plan.yml
@@ -1,0 +1,22 @@
+description: >
+  Comment the output of Terraform Plan on an open PR.
+parameters:
+  path:
+    type: string
+    description: "The path to the output of terraform plan."
+  github_token:
+    type: env_var_name
+    default: GITHUB_TOKEN
+    description: "The environment variable that contains the GitHub token of the user that will post the comment."
+  github_user:
+    type: env_var_name
+    default: GITHUB_USER
+    description: "The environment variable that contains the GitHub username of the user that will post the comment."
+
+executor: default
+
+steps:
+  - comment_terraform_plan:
+      path: << parameters.path >>
+      github_token: << parameters.github_token >>
+      github_user: << parameters.github_user >>

--- a/src/scripts/comment-terraform-plan.sh
+++ b/src/scripts/comment-terraform-plan.sh
@@ -1,17 +1,17 @@
 PARAM_GITHUB_USER=$(eval echo "\$$GITHUB_USER_ENV_VAR_NAME")
 PARAM_GITHUB_TOKEN=$(eval echo "\$$GITHUB_TOKEN_ENV_VAR_NAME")
 
-if [ "${PARAM_GITHUB_TOKEN}" = "" ];then
+if [ "${PARAM_GITHUB_TOKEN}" = "" ]; then
   echo "GITHUB_TOKEN not set."
   exit 1
 fi
 
-if [ "${PARAM_GITHUB_USER}" = "" ];then
+if [ "${PARAM_GITHUB_USER}" = "" ]; then
   echo "GITHUB_USER not set."
   exit 1
 fi
 
-if [ "${PARAM_PLAN}" = "" ];then
+if [ "${PARAM_PLAN}" = "" ]; then
   echo "No terraform plan output provided."
   exit 1
 fi
@@ -19,7 +19,7 @@ fi
 PR_RESPONSE=$(curl --location --request GET "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" \
 -u "$PARAM_GITHUB_USER":"$PARAM_GITHUB_TOKEN")
 
-if [ "$(echo ${PR_RESPONSE} | jq length)" -eq 0 ]; then
+if [ "$(echo "${PR_RESPONSE}" | jq length)" -eq 0 ]; then
   echo "No PR found to update, skipping."
   # Exit 0 to not error and stop the workflow.
   exit 0
@@ -27,7 +27,7 @@ fi
 
 COMMENT=$(jo body="\`\`\`\n$(terraform show -no-color "${PARAM_PLAN}")")
 
-PR_COMMENT_URL=$(echo ${PR_RESPONSE} | jq --raw-output ".[]._links.comments.href")
+PR_COMMENT_URL=$(echo "${PR_RESPONSE}" | jq --raw-output ".[]._links.comments.href")
 
 curl --location --request POST "${PR_COMMENT_URL}" \
 -u "${PARAM_GITHUB_USER}":"${PARAM_GITHUB_TOKEN}" \

--- a/src/scripts/comment-terraform-plan.sh
+++ b/src/scripts/comment-terraform-plan.sh
@@ -17,7 +17,7 @@ if [ "${PARAM_PLAN}" = "" ];then
 fi
 
 PR_RESPONSE=$(curl --location --request GET "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" \
--u $PARAM_GITHUB_USER:$PARAM_GITHUB_TOKEN)
+-u "$PARAM_GITHUB_USER":"$PARAM_GITHUB_TOKEN")
 
 if [ "$(echo ${PR_RESPONSE} | jq length)" -eq 0 ]; then
   echo "No PR found to update, skipping."
@@ -25,12 +25,12 @@ if [ "$(echo ${PR_RESPONSE} | jq length)" -eq 0 ]; then
   exit 0
 fi
 
-COMMENT=$(jo body="\`\`\`\n$(terraform show -no-color ${PARAM_PLAN})")
+COMMENT=$(jo body="\`\`\`\n$(terraform show -no-color "${PARAM_PLAN}")")
 
 PR_COMMENT_URL=$(echo ${PR_RESPONSE} | jq --raw-output ".[]._links.comments.href")
 
 curl --location --request POST "${PR_COMMENT_URL}" \
--u ${PARAM_GITHUB_USER}:${PARAM_GITHUB_TOKEN} \
+-u "${PARAM_GITHUB_USER}":"${PARAM_GITHUB_TOKEN}" \
 --header 'Content-Type: application/json' \
 --data-raw "${COMMENT}"
 

--- a/src/scripts/comment-terraform-plan.sh
+++ b/src/scripts/comment-terraform-plan.sh
@@ -1,0 +1,37 @@
+PARAM_GITHUB_USER=$(eval echo "\$$GITHUB_USER_ENV_VAR_NAME")
+PARAM_GITHUB_TOKEN=$(eval echo "\$$GITHUB_TOKEN_ENV_VAR_NAME")
+
+if [ "${PARAM_GITHUB_TOKEN}" = "" ];then
+  echo "GITHUB_TOKEN not set."
+  exit 1
+fi
+
+if [ "${PARAM_GITHUB_USER}" = "" ];then
+  echo "GITHUB_USER not set."
+  exit 1
+fi
+
+if [ "${PARAM_PLAN}" = "" ];then
+  echo "No terraform plan output provided."
+  exit 1
+fi
+
+PR_RESPONSE=$(curl --location --request GET "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" \
+-u $PARAM_GITHUB_USER:$PARAM_GITHUB_TOKEN)
+
+if [ "$(echo ${PR_RESPONSE} | jq length)" -eq 0 ]; then
+  echo "No PR found to update, skipping."
+  # Exit 0 to not error and stop the workflow.
+  exit 0
+fi
+
+COMMENT=$(jo body="\`\`\`\n$(terraform show -no-color ${PARAM_PLAN})")
+
+PR_COMMENT_URL=$(echo ${PR_RESPONSE} | jq --raw-output ".[]._links.comments.href")
+
+curl --location --request POST "${PR_COMMENT_URL}" \
+-u ${PARAM_GITHUB_USER}:${PARAM_GITHUB_TOKEN} \
+--header 'Content-Type: application/json' \
+--data-raw "${COMMENT}"
+
+exit 0


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Add job to run Terraform plan, extract the planned changes, and post a comment on the pull request that generated the changes.

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

Currently a version of this job is used in [`trade-tariff-team`](https://github.com/trade-tariff/trade-tariff-team).

As part of [HOTT-2761](https://transformuk.atlassian.net/browse/HOTT-2761) I want to move this functionality into the orb so that it can be shared easily to multiple repos.
