### PR TITLE
[semver:minor] HOTT-3753: Add build-and-push

### DIFF
--- a/src/commands/build-and-push.yml
+++ b/src/commands/build-and-push.yml
@@ -19,18 +19,11 @@ parameters:
     description: AWS Region
 
 steps:
-  - checkout
-
-  - setup_remote_docker:
-      version: 20.10.11
-      docker_layer_caching: false
-
-  - aws-cli/install
-
   - run:
       environment:
         SSM_PARAMETER: << parameters.ssm_parameter >>
         IMAGE_NAME: << parameters.image_name >>
         AWS_DEFAULT_REGION: << parameters.aws_default_region >>
+        ENVIRONMENT: << parameters.environment >>
       name: Build and push to ECR
       command: <<include(scripts/ecr.sh)>>

--- a/src/commands/build-and-push.yml
+++ b/src/commands/build-and-push.yml
@@ -1,0 +1,36 @@
+description: >
+  Build image and push to ECR
+
+parameters:
+  ssm_parameter:
+    type: string
+    description: SSM Parameter that contains the ECR URL
+
+  environment:
+    type: string
+    description: Deployment environment, e.g. 'development'
+
+  image_name:
+    type: string
+    description: Name of the Docker image to build
+
+  aws_default_region:
+    type: string
+    description: AWS Region
+
+steps:
+  - checkout
+
+  - setup_remote_docker:
+      version: 20.10.11
+      docker_layer_caching: false
+
+  - aws-cli/install
+
+  - run:
+      environment:
+        SSM_PARAMETER: << parameters.ssm_parameter >>
+        IMAGE_NAME: << parameters.image_name >>
+        AWS_DEFAULT_REGION: << parameters.aws_default_region >>
+      name: Build and push to ECR
+      command: <<include(scripts/ecr.sh)>>

--- a/src/executors/ruby.yml
+++ b/src/executors/ruby.yml
@@ -1,0 +1,15 @@
+description: >
+  Ruby executor for building docker images
+
+docker:
+  - image: 'cimg/ruby:<< parameters.tag >>'
+
+parameters:
+  tag:
+    default: "3.2.2-node"
+    description: >
+      Pick a specific circleci/ruby image variant:
+      https://hub.docker.com/r/cimg/ruby/tags
+
+      Defaults to `3.2.2-node`.
+    type: string

--- a/src/jobs/build-and-push.yml
+++ b/src/jobs/build-and-push.yml
@@ -28,7 +28,16 @@ parameters:
     description: AWS Region
 
 steps:
+  - checkout
+
+  - setup_remote_docker:
+      version: 20.10.11
+      docker_layer_caching: false
+
+  - aws-cli/install
+
   - build-and-push:
       ssm_parameter: << parameters.ssm_parameter >>
       image_name: << parameters.image_name >>
       aws_default_region: << parameters.aws_default_region >>
+      environment: << parameters.environment >>

--- a/src/jobs/build-and-push.yml
+++ b/src/jobs/build-and-push.yml
@@ -1,0 +1,34 @@
+description: >
+  Build and push image to AWS ECR
+
+executor:
+  name: ruby
+  tag: << parameters.ruby_tag >>
+
+parameters:
+  ruby_tag:
+    type: string
+    default: "3.2.2-node"
+    description: cimg/ruby tag to use
+
+  ssm_parameter:
+    type: string
+    description: SSM Parameter that contains the ECR URL
+
+  environment:
+    type: string
+    description: Deployment environment, e.g. 'development'
+
+  image_name:
+    type: string
+    description: Name of the Docker image to build
+
+  aws_default_region:
+    type: string
+    description: AWS Region
+
+steps:
+  - build-and-push:
+      ssm_parameter: << parameters.ssm_parameter >>
+      image_name: << parameters.image_name >>
+      aws_default_region: << parameters.aws_default_region >>

--- a/src/scripts/ecr.sh
+++ b/src/scripts/ecr.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+docker_tag=$(git rev-parse --short HEAD)
+container="${IMAGE_NAME}-${ENVIRONMENT}:${docker_tag}"
+
+function fetch_ecr_url {
+  json=$(aws ssm get-parameter              \
+  --name "/${ENVIRONMENT}/${SSM_PARAMETER}" \
+  --with-decryption                         \
+  --output json                             \
+  --color off)
+
+  output=$(jq -r .Parameter.Value <<< "${json}")
+
+  if [ -n "${output}" ]; then
+    echo "${output}"
+  else
+    exit 1
+  fi
+}
+
+ecr_url=$(fetch_ecr_url)
+
+docker build -t "$container" .
+docker tag "${container}" "${ecr_url}:${docker_tag}"
+
+aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" |
+  docker login --username AWS --password-stdin "${ecr_url}"
+
+docker push "${ecr_url}:${docker_tag}"

--- a/src/scripts/ecr.sh
+++ b/src/scripts/ecr.sh
@@ -4,10 +4,10 @@ docker_tag=$(git rev-parse --short HEAD)
 container="${IMAGE_NAME}-${ENVIRONMENT}:${docker_tag}"
 
 function fetch_ecr_url {
-  json=$(aws ssm get-parameter              \
-  --name "/${ENVIRONMENT}/${SSM_PARAMETER}" \
-  --with-decryption                         \
-  --output json                             \
+  json=$(aws ssm get-parameter \
+  --name "${SSM_PARAMETER}"    \
+  --with-decryption            \
+  --output json                \
   --color off)
 
   output=$(jq -r .Parameter.Value <<< "${json}")


### PR DESCRIPTION
Ports the new `build_and_push` command for building and pushing images to the new AWS environment.

Also adds the `ruby` executor.