### PR TITLE
BAU: Ensure REVISION file is present in images

### DIFF
--- a/src/scripts/ecr.sh
+++ b/src/scripts/ecr.sh
@@ -21,7 +21,7 @@ function fetch_ecr_url {
 
 ecr_url=$(fetch_ecr_url)
 
-echo $(git rev-parse --short HEAD) > REVISION
+git rev-parse --short HEAD > REVISION
 
 docker build -t "$container" .
 docker tag "${container}" "${ecr_url}:${docker_tag}"

--- a/src/scripts/ecr.sh
+++ b/src/scripts/ecr.sh
@@ -21,6 +21,8 @@ function fetch_ecr_url {
 
 ecr_url=$(fetch_ecr_url)
 
+echo $(git rev-parse --short HEAD) > REVISION
+
 docker build -t "$container" .
 docker tag "${container}" "${ecr_url}:${docker_tag}"
 


### PR DESCRIPTION
The apps rely on `REVISION` to present the `GIT_SHA` to the healthcheck controller.

This was supplied through a step before calling `docker build`, by `echo`ing the output of `git rev-parse --short HEAD` into a file.

This PR adds this step into the build script which will ensure the file is present in all containers built using the new orb job.