### PR TITLE
BAU: Remove space param from healthcheck

### DIFF
--- a/src/commands/healthcheck.yml
+++ b/src/commands/healthcheck.yml
@@ -5,9 +5,6 @@ parameters:
   cf_app:
     description: PaaS App name
     type: string
-  space:
-    description: Environment name
-    type: string
   environment_key:
     description: Environment key, i.e. 'dev'
     type: string
@@ -21,7 +18,6 @@ steps:
       name: Verify if dark app is working
       environment:
         PARAM_CF_APP: << parameters.cf_app >>
-        PARAM_SPACE: << parameters.space >>
         PARAM_ENV_KEY: << parameters.environment_key >>
         HEALTHCHECK_PATH: << parameters.healthcheck_path >>
       command: <<include(scripts/healthcheck.sh)>>

--- a/src/commands/test-dark-app.yml
+++ b/src/commands/test-dark-app.yml
@@ -2,9 +2,6 @@ description: >
   Healthchecks dark app on PaaS
 
 parameters:
-  space:
-    description: Which environment you are deploying to
-    type: string
   environment_key:
     description: Environment key for app, e.g. dev
     type: string
@@ -23,6 +20,5 @@ steps:
 
   - healthcheck:
       cf_app: << parameters.cf_app >>
-      space: << parameters.space >>
       environment_key: << parameters.environment_key >>
       healthcheck_path: << parameters.healthcheck_path >>

--- a/src/scripts/healthcheck.sh
+++ b/src/scripts/healthcheck.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 cf_app=$(eval echo "\$$PARAM_CF_APP")
-space=$(eval echo "\$$PARAM_SPACE")
 env_key=$(eval echo "\$$PARAM_ENV_KEY")
 path=$(eval echo "\$$HEALTHCHECK_PATH")
 
@@ -9,11 +8,6 @@ dark_app="$cf_app-$env_key-dark"
 
 if [ "${cf_app}" = "" ]; then
   echo "cf_app parameter not set."
-  exit 1
-fi
-
-if [ "${space}" = "" ]; then
-  echo "space parameter not set."
   exit 1
 fi
 


### PR DESCRIPTION
This completely unused parameter is not only present but throwing errors downstream