### PR TITLE
BAU: Remove param checking from healthcheck

### DIFF
--- a/src/scripts/healthcheck.sh
+++ b/src/scripts/healthcheck.sh
@@ -1,29 +1,10 @@
 #!/bin/bash
 
-cf_app=$(eval echo "\$$PARAM_CF_APP")
-env_key=$(eval echo "\$$PARAM_ENV_KEY")
-path=$(eval echo "\$$HEALTHCHECK_PATH")
-
-dark_app="$cf_app-$env_key-dark"
-
-if [ "${cf_app}" = "" ]; then
-  echo "cf_app parameter not set."
-  exit 1
-fi
-
-if [ "${env_key}" = "" ]; then
-  echo "environment_key parameter not set."
-  exit 1
-fi
-
-if [ "${path}" = "" ]; then
-  echo "healthcheck_path parameter not set."
-  exit 1
-fi
+dark_app="${PARAM_CF_APP}-${PARAM_ENV_KEY}-dark"
 
 # Verify healthcheck endpoint on new app
 healthcheck_response=$(curl -s -o /dev/null -w "%{http_code}" \
-  "https://$dark_app.london.cloudapps.digital/${path}")
+  "https://$dark_app.london.cloudapps.digital/${HEALTHCHECK_PATH}")
 
 if [ "$healthcheck_response" -ne 200 ]; then
   echo "dark route not available, failing deploy ($healthcheck_response)"


### PR DESCRIPTION
We're in control of these variables so we don't need to check them.