### PR TITLE
BAU: Allow Custom Executor in Build Job

### DIFF
--- a/src/executors/python.yml
+++ b/src/executors/python.yml
@@ -1,0 +1,15 @@
+description: >
+  Python executor for building docker images
+
+docker:
+  - image: 'cimg/python:<< parameters.tag >>'
+
+parameters:
+  tag:
+    default: "3.11.2"
+    description: >
+      Pick a specific circleci/python image variant:
+      https://hub.docker.com/r/cimg/python/tags
+
+      Defaults to `3.11.2`.
+    type: string

--- a/src/jobs/build-and-push.yml
+++ b/src/jobs/build-and-push.yml
@@ -1,13 +1,11 @@
 description: >
   Build and push image to AWS ECR
 
-executor:
-  name: << parameters.image >>
-  tag: << parameters.tag >>
+executor: << parameters.image >>
 
 parameters:
   image:
-    type: string
+    type: executor
     default: "ruby"
     description: "Executor to use. Defaults to 'ruby'."
 

--- a/src/jobs/build-and-push.yml
+++ b/src/jobs/build-and-push.yml
@@ -2,7 +2,7 @@ description: >
   Build and push image to AWS ECR
 
 executor:
-  image: << parameters.image >>
+  name: << parameters.image >>
   tag: << parameters.tag >>
 
 parameters:
@@ -13,6 +13,7 @@ parameters:
 
   tag:
     type: string
+    default: default
     description: "Tag for executor image to use. Defaults to executor default."
 
   ssm_parameter:

--- a/src/jobs/build-and-push.yml
+++ b/src/jobs/build-and-push.yml
@@ -2,14 +2,18 @@ description: >
   Build and push image to AWS ECR
 
 executor:
-  name: ruby
-  tag: << parameters.ruby_tag >>
+  name: << parameters.executor >>
+  tag: << parameters.tag >>
 
 parameters:
-  ruby_tag:
+  executor:
     type: string
-    default: "3.2.2-node"
-    description: cimg/ruby tag to use
+    default: "ruby"
+    description: "Executor to use. Defaults to 'ruby'."
+
+  tag:
+    type: string
+    description: "Tag for executor image to use. Defaults to executor default."
 
   ssm_parameter:
     type: string

--- a/src/jobs/build-and-push.yml
+++ b/src/jobs/build-and-push.yml
@@ -2,11 +2,11 @@ description: >
   Build and push image to AWS ECR
 
 executor:
-  name: << parameters.executor >>
+  image: << parameters.image >>
   tag: << parameters.tag >>
 
 parameters:
-  executor:
+  image:
     type: string
     default: "ruby"
     description: "Executor to use. Defaults to 'ruby'."


### PR DESCRIPTION
Not all the apps use Ruby - so we need to allow them to use a custom executor.

The default executor for `build-and-push` falls back to `cimg/ruby:3.2.2-node`, with the default tag as per the executor configuration.

This also adds the Python executor, using `cimg/python`, with a default tag of `3.11.2` as used by the Search Query Parser.