### PR TITLE
[semver:minor] HOTT-4598: Update Tag Docker Release Job

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/src/commands/tag-docker-release.yml
+++ b/src/commands/tag-docker-release.yml
@@ -15,24 +15,6 @@ steps:
   - aws-cli/install
   - run:
       name: Tag Docker Image as production release
-      command: |
-        RELEASE_VERSION=$(< << parameters.release-version-file >>)
-        echo "RELEASE_VERSION is '${RELEASE_VERSION}'"
-
-        if [ -z "${ECR_REPO}" ]; then
-          echo "Missing ECR_REPO"
-          exit 1
-        fi
-
-        if [ -z "${RELEASE_VERSION}" ]; then
-          echo "Missing RELEASE_VERSION"
-          exit 1
-        fi
-
-        DOCKER_IMAGE="${ECR_REPO}/<< parameters.image-name >>"
-        IMAGE_TAG="release-${RELEASE_VERSION}"
-
-        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ECR_REPO
-        docker pull "${DOCKER_IMAGE}:${CIRCLE_SHA1}"
-        docker tag "${DOCKER_IMAGE}:${CIRCLE_SHA1}" "${DOCKER_IMAGE}:${IMAGE_TAG}"
-        docker push "${DOCKER_IMAGE}:${IMAGE_TAG}"
+      environment:
+        RELEASE_FILE: << parameters.release-version-file >>
+      command: <<include(scripts/tag.sh)>>

--- a/src/scripts/tag.sh
+++ b/src/scripts/tag.sh
@@ -2,9 +2,6 @@
 
 docker_tag=$(git rev-parse --short HEAD)
 
-RELEASE_VERSION=$(< RELEASE_FILE)
-echo "RELEASE_VERSION is '${RELEASE_VERSION}'"
-
 if [ -z "${ECR_REPO}" ]; then
   echo "Missing ECR_REPO"
   exit 1
@@ -15,10 +12,13 @@ if [ -z "${RELEASE_VERSION}" ]; then
   exit 1
 fi
 
+RELEASE_VERSION=$(< RELEASE_FILE)
+echo "RELEASE_VERSION is '${RELEASE_VERSION}'"
+
 DOCKER_IMAGE="${ECR_REPO}/<< parameters.image-name >>"
 IMAGE_TAG="release-${RELEASE_VERSION}"
 
-aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ECR_REPO
+aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin "$ECR_REPO"
 docker pull "${DOCKER_IMAGE}:${docker_tag}"
 docker tag "${DOCKER_IMAGE}:${docker_tag}" "${DOCKER_IMAGE}:${IMAGE_TAG}"
 docker push "${DOCKER_IMAGE}:${IMAGE_TAG}"

--- a/src/scripts/tag.sh
+++ b/src/scripts/tag.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+docker_tag=$(git rev-parse --short HEAD)
+
+RELEASE_VERSION=$(< RELEASE_FILE)
+echo "RELEASE_VERSION is '${RELEASE_VERSION}'"
+
+if [ -z "${ECR_REPO}" ]; then
+  echo "Missing ECR_REPO"
+  exit 1
+fi
+
+if [ -z "${RELEASE_VERSION}" ]; then
+  echo "Missing RELEASE_VERSION"
+  exit 1
+fi
+
+DOCKER_IMAGE="${ECR_REPO}/<< parameters.image-name >>"
+IMAGE_TAG="release-${RELEASE_VERSION}"
+
+aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ECR_REPO
+docker pull "${DOCKER_IMAGE}:${docker_tag}"
+docker tag "${DOCKER_IMAGE}:${docker_tag}" "${DOCKER_IMAGE}:${IMAGE_TAG}"
+docker push "${DOCKER_IMAGE}:${IMAGE_TAG}"


### PR DESCRIPTION
Since moving to our new infrastructure, we've moved to using the `short` git SHA.

## I Have

- Moved arbitrary bash commands into a script file such that it can be linted as part of CI.
- Updated the docker tagging script such that releases will work correctly.