### PR TITLE
HOTT-4755: Bumps ruby to 3.3.0

### DIFF
--- a/src/executors/ruby.yml
+++ b/src/executors/ruby.yml
@@ -6,10 +6,10 @@ docker:
 
 parameters:
   tag:
-    default: "3.2.2-node"
+    default: "3.3.0-node"
     description: >
       Pick a specific circleci/ruby image variant:
       https://hub.docker.com/r/cimg/ruby/tags
 
-      Defaults to `3.2.2-node`.
+      Defaults to `3.3.0-node`.
     type: string


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [ ] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Bumps the default version of the ruby-node executor to 3.3.0

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

 **Closes Issues:**
-  ISSUE URL

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.
