### PR TITLE
BAU: Fix repo targeting in release notes job

### DIFF
--- a/src/commands/notify-production-release.yml
+++ b/src/commands/notify-production-release.yml
@@ -15,12 +15,12 @@ steps:
       name: Read release name
       command: |
         RELEASE_NAME="<< parameters.release-tag >>"
-        gh release view "${RELEASE_NAME}" --json body | jq .body > release-notes.txt
+        gh release view "${RELEASE_NAME}" -R trade-tariff/${CIRCLE_PROJECT_REPONAME} --json body | jq .body > release-notes.txt
         echo 'export RELEASE_NOTES="$(< release-notes.txt)"' >> $BASH_ENV
   - run:
       name: Display release notes
       command: |
-        gh release view "${RELEASE_NAME}"
+        gh release view "${RELEASE_NAME}" -R trade-tariff/${CIRCLE_PROJECT_REPONAME}
   - slack/notify:
       channel: << parameters.slack-channel >>
       event: pass
@@ -39,7 +39,7 @@ steps:
               "type": "section",
               "text": {
                 "type": "mrkdwn",
-                "text": ${RELEASE_NOTES}
+                "text": "${RELEASE_NOTES}"
               }
             },
             {


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added `-R` switch to `gh release` commands.

## Why?

I am doing this because:

- To target the correct repository to view release notes, we should use this flag - it's more convenient than running a `checkout` job.
