### PR TITLE
BAU: Fix Production Deployment Notification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/src/commands/notify-production-release.yml
+++ b/src/commands/notify-production-release.yml
@@ -15,12 +15,8 @@ steps:
       name: Read release name
       command: |
         RELEASE_NAME="<< parameters.release-tag >>"
-        gh release view "${RELEASE_NAME}" -R trade-tariff/${CIRCLE_PROJECT_REPONAME} --json body | jq .body > release-notes.txt
-        echo 'export RELEASE_NOTES="$(< release-notes.txt)"' >> $BASH_ENV
-  - run:
-      name: Display release notes
-      command: |
-        gh release view "${RELEASE_NAME}" -R trade-tariff/${CIRCLE_PROJECT_REPONAME}
+        gh release view "${RELEASE}" -R trade-tariff/${CIRCLE_PROJECT_REPONAME} --json name | jq .name > release-name
+        echo 'export RELEASE="$(cat release-name)"' >> $BASH_ENV
   - slack/notify:
       channel: << parameters.slack-channel >>
       event: pass
@@ -39,7 +35,7 @@ steps:
               "type": "section",
               "text": {
                 "type": "mrkdwn",
-                "text": "${RELEASE_NOTES}"
+                "text": "[View on GitHub](https://github.com/trade-tariff/${CIRCLE_PROJECT_REPONAME}/releases/tag/${RELEASE})"
               }
             },
             {


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Instead of spitting out the entire body of the GitHub release to Slack, just emit the URL as a message with context.

## Why?

I am doing this because:

- Notifications in the orb have been broken for a while and multiple attempts to fix them have been flaky or just made the orb worse. 