### PR TITLE
BAU: Bump to default stable docker engine

### DIFF
--- a/src/commands/tag-docker-release.yml
+++ b/src/commands/tag-docker-release.yml
@@ -10,7 +10,7 @@ parameters:
 
 steps:
   - setup_remote_docker:
-      version: 20.10.11
+      version: default
       docker_layer_caching: false
   - aws-cli/install
   - run:

--- a/src/jobs/build-and-push.yml
+++ b/src/jobs/build-and-push.yml
@@ -30,7 +30,7 @@ steps:
   - checkout
 
   - setup_remote_docker:
-      version: 20.10.11
+      version: default
       docker_layer_caching: false
 
   - aws-cli/install


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Altered remote docker engine to use non-deprecated versions

## Why?

I am doing this because:

- The versions we're using are EOL
